### PR TITLE
fix api call for account with many devices

### DIFF
--- a/zont.py
+++ b/zont.py
@@ -49,7 +49,7 @@ def status_lighting():
     """Проверяет статус освещения True - вкл, False - выкл"""
 
     url = 'https://zont-online.ru/api/devices'
-    body = {'load_io': True}
+    body = {'load_io': True, 'device_ids': [DEVICEID]}
 
     response = requests.post(url=url, json=body, headers=HEADERS)
 


### PR DESCRIPTION
Если в аккаунте устройств больше, чем одно, то скорее всего будет ошибка, так как мы возьмем из апишки не правильное устройство. Поэтому в теле запроса стоит указать точно, какое устройство мы хотим запросить